### PR TITLE
Update dpdk version to 20.08

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "dpdk"]
 	path = dpdk
-	url = git://dpdk.org/dpdk
+	url = https://github.com/DPDK/dpdk.git

--- a/dpdk-apps/Makefile
+++ b/dpdk-apps/Makefile
@@ -72,7 +72,7 @@ WERROR_FLAGS += -Wformat-nonliteral -Wformat-security
 WERROR_FLAGS += -Wundef -Wwrite-strings
 
 CFLAGS += $(WERROR_FLAGS) -mavx2
-LDFLAGS= -Wl,--whole-archive -Wl,-ldpdk -Wl,--no-whole-archive -lrt -lpthread -lm -ldl -libverbs -lmlx5 -L$(RTE_SDK)/x86_64-native-linuxapp-gcc/lib -lconfig -lnuma -lgcov --coverage -lpcap
+LDFLAGS= -Wl,--whole-archive -Wl,-ldpdk -Wl,--no-whole-archive -lrt -lpthread -lm -ldl -L$(RTE_SDK)/x86_64-native-linuxapp-gcc/lib -lconfig -lnuma -lgcov --coverage -lpcap
 
 SRCS_C := $(addprefix $(ROOTDIR)/netstack/dp/, $(DP_SRC)) $(addprefix $(ROOTDIR)/netstack/net/, $(NET_SRC)) $(addprefix $(R2P2LIB_DIR)/, $(R2P2_SRC_C))
 OBJS_C := $(patsubst %.c, %.o, $(SRCS_C))

--- a/dpdk-apps/Makefile
+++ b/dpdk-apps/Makefile
@@ -72,7 +72,7 @@ WERROR_FLAGS += -Wformat-nonliteral -Wformat-security
 WERROR_FLAGS += -Wundef -Wwrite-strings
 
 CFLAGS += $(WERROR_FLAGS) -mavx2
-LDFLAGS= -Wl,--whole-archive -Wl,-ldpdk -Wl,--no-whole-archive -lrt -lpthread -lm -ldl -L$(RTE_SDK)/x86_64-native-linuxapp-gcc/lib -lconfig -lnuma -lgcov --coverage -lpcap
+LDFLAGS= -Wl,--whole-archive -Wl,-ldpdk -Wl,--no-whole-archive -lrt -lpthread -lm -ldl -libverbs -lmlx5 -L$(RTE_SDK)/x86_64-native-linuxapp-gcc/lib -lconfig -lnuma -lgcov --coverage -lpcap
 
 SRCS_C := $(addprefix $(ROOTDIR)/netstack/dp/, $(DP_SRC)) $(addprefix $(ROOTDIR)/netstack/net/, $(NET_SRC)) $(addprefix $(R2P2LIB_DIR)/, $(R2P2_SRC_C))
 OBJS_C := $(patsubst %.c, %.o, $(SRCS_C))

--- a/netstack/dp/dpdk.c
+++ b/netstack/dp/dpdk.c
@@ -53,23 +53,12 @@ static const struct rte_eth_conf port_conf = {
 	.rxmode =
 		{
 			.split_hdr_size = 0,
-			.max_rx_pkt_len = RTE_ETHER_MAX_LEN, /** added in hope of fixing Ethdev port_id=0 max_rx_pkt_len 0 < min valid value 64
+			.max_rx_pkt_len = RTE_ETHER_MAX_LEN, /** added to fix "Ethdev port_id=0 max_rx_pkt_len 0 < min valid value 64"*/
 			.offloads = DEV_RX_OFFLOAD_HEADER_SPLIT
 						| DEV_RX_OFFLOAD_OUTER_IPV4_CKSUM
 						| DEV_RX_OFFLOAD_VLAN_FILTER
 						| DEV_RX_OFFLOAD_JUMBO_FRAME
 						| DEV_RX_OFFLOAD_KEEP_CRC,
-			// problem DEV_RX_OFFLOAD_HEADER_SPLIT
-			// .header_split = 0,   /**< Header Split disabled */
-			// problem DEV_RX_OFFLOAD_IPV4_CKSUM
-			// DEV_RX_OFFLOAD_OUTER_IPV4_CKSUM <---???
-			// .hw_ip_checksum = 1, /**< IP checksum offload disabled */
-			// problem DEV_RX_OFFLOAD_VLAN_FILTER
-			// .hw_vlan_filter = 0, /**< VLAN filtering disabled */
-			// problem DEV_RX_OFFLOAD_JUMBO_FRAME
-			// .jumbo_frame = 0,	/**< Jumbo Frame Support disabled */
-			// problem DEV_RX_OFFLOAD_KEEP_CRC not sure
-			// .hw_strip_crc = 1,   /**< CRC stripped by hardware */
 			.mq_mode = ETH_MQ_RX_RSS,
 		},
 	.rx_adv_conf =

--- a/netstack/dp/dpdk.c
+++ b/netstack/dp/dpdk.c
@@ -54,7 +54,7 @@ static const struct rte_eth_conf port_conf = {
 		{
 			.split_hdr_size = 0,
 			.max_rx_pkt_len = RTE_ETHER_MAX_LEN, /** added to fix "Ethdev port_id=0 max_rx_pkt_len 0 < min valid value 64"*/
-			.offloads = DEV_RX_OFFLOAD_KEEP_CRC,
+			.offloads = DEV_RX_OFFLOAD_IPV4_CKSUM | DEV_RX_OFFLOAD_KEEP_CRC,
 			.mq_mode = ETH_MQ_RX_RSS,
 		},
 	.rx_adv_conf =

--- a/netstack/dp/dpdk.c
+++ b/netstack/dp/dpdk.c
@@ -53,11 +53,23 @@ static const struct rte_eth_conf port_conf = {
 	.rxmode =
 		{
 			.split_hdr_size = 0,
-			.header_split = 0,   /**< Header Split disabled */
-			.hw_ip_checksum = 1, /**< IP checksum offload disabled */
-			.hw_vlan_filter = 0, /**< VLAN filtering disabled */
-			.jumbo_frame = 0,	/**< Jumbo Frame Support disabled */
-			.hw_strip_crc = 1,   /**< CRC stripped by hardware */
+			.max_rx_pkt_len = RTE_ETHER_MAX_LEN, /** added in hope of fixing Ethdev port_id=0 max_rx_pkt_len 0 < min valid value 64
+			.offloads = DEV_RX_OFFLOAD_HEADER_SPLIT
+						| DEV_RX_OFFLOAD_OUTER_IPV4_CKSUM
+						| DEV_RX_OFFLOAD_VLAN_FILTER
+						| DEV_RX_OFFLOAD_JUMBO_FRAME
+						| DEV_RX_OFFLOAD_KEEP_CRC,
+			// problem DEV_RX_OFFLOAD_HEADER_SPLIT
+			// .header_split = 0,   /**< Header Split disabled */
+			// problem DEV_RX_OFFLOAD_IPV4_CKSUM
+			// DEV_RX_OFFLOAD_OUTER_IPV4_CKSUM <---???
+			// .hw_ip_checksum = 1, /**< IP checksum offload disabled */
+			// problem DEV_RX_OFFLOAD_VLAN_FILTER
+			// .hw_vlan_filter = 0, /**< VLAN filtering disabled */
+			// problem DEV_RX_OFFLOAD_JUMBO_FRAME
+			// .jumbo_frame = 0,	/**< Jumbo Frame Support disabled */
+			// problem DEV_RX_OFFLOAD_KEEP_CRC not sure
+			// .hw_strip_crc = 1,   /**< CRC stripped by hardware */
 			.mq_mode = ETH_MQ_RX_RSS,
 		},
 	.rx_adv_conf =
@@ -107,7 +119,7 @@ void dpdk_init(int *argc, char ***argv)
 	if (pktmbuf_pool == NULL)
 		rte_exit(EXIT_FAILURE, "Cannot init mbuf pool\n");
 
-	nb_ports = rte_eth_dev_count();
+	nb_ports = rte_eth_dev_count_avail();
 	if (nb_ports == 0)
 		rte_exit(EXIT_FAILURE, "No Ethernet ports - bye\n");
 

--- a/netstack/dp/dpdk.c
+++ b/netstack/dp/dpdk.c
@@ -54,11 +54,7 @@ static const struct rte_eth_conf port_conf = {
 		{
 			.split_hdr_size = 0,
 			.max_rx_pkt_len = RTE_ETHER_MAX_LEN, /** added to fix "Ethdev port_id=0 max_rx_pkt_len 0 < min valid value 64"*/
-			.offloads = DEV_RX_OFFLOAD_HEADER_SPLIT
-						| DEV_RX_OFFLOAD_OUTER_IPV4_CKSUM
-						| DEV_RX_OFFLOAD_VLAN_FILTER
-						| DEV_RX_OFFLOAD_JUMBO_FRAME
-						| DEV_RX_OFFLOAD_KEEP_CRC,
+			.offloads = DEV_RX_OFFLOAD_KEEP_CRC,
 			.mq_mode = ETH_MQ_RX_RSS,
 		},
 	.rx_adv_conf =

--- a/netstack/inc/net/igmp.h
+++ b/netstack/inc/net/igmp.h
@@ -19,4 +19,4 @@ struct __attribute__((packed)) igmpv2_hdr {
 	uint32_t gaddr;
 };
 
-void igmp_in(void *pkt_buf, struct ipv4_hdr *iph, struct igmpv2_hdr *igmph);
+void igmp_in(void *pkt_buf, struct rte_ipv4_hdr *iph, struct igmpv2_hdr *igmph);

--- a/netstack/inc/net/net.h
+++ b/netstack/inc/net/net.h
@@ -42,10 +42,10 @@
 #include <r2p2/cfg.h>
 
 #define ETH_MTU 1500
-#define UDP_MAX_LEN (ETH_MTU - sizeof(struct ipv4_hdr) - sizeof(struct udp_hdr))
-#define L2_HDR_LEN sizeof(struct ether_hdr)
-#define L3_HDR_LEN (L2_HDR_LEN + sizeof(struct ipv4_hdr))
-#define UDP_HDRS_LEN (L3_HDR_LEN + sizeof(struct udp_hdr))
+#define UDP_MAX_LEN (ETH_MTU - sizeof(struct rte_ipv4_hdr) - sizeof(struct rte_udp_hdr))
+#define L2_HDR_LEN sizeof(struct rte_ether_hdr)
+#define L3_HDR_LEN (L2_HDR_LEN + sizeof(struct rte_ipv4_hdr))
+#define UDP_HDRS_LEN (L3_HDR_LEN + sizeof(struct rte_udp_hdr))
 
 struct ip_tuple {
 	uint32_t src_ip;
@@ -64,21 +64,21 @@ int add_arp_entry(const char *ip, const char *mac);
 /* packet processing */
 void eth_in(struct rte_mbuf *pkt_buf);
 int eth_out(struct rte_mbuf *pkt_buf, uint16_t h_proto,
-			struct ether_addr *dst_haddr, uint16_t iplen);
-void arp_in(struct rte_mbuf *pkt_buf, struct arp_hdr *arph);
-struct ether_addr *arp_lookup_mac(uint32_t addr);
-void ip_in(struct rte_mbuf *pkt_buf, struct ipv4_hdr *iph);
-void ip_out(struct rte_mbuf *pkt_buf, struct ipv4_hdr *iph, uint32_t src_ip,
+			struct rte_ether_addr *dst_haddr, uint16_t iplen);
+void arp_in(struct rte_mbuf *pkt_buf, struct rte_arp_hdr *arph);
+struct rte_ether_addr *arp_lookup_mac(uint32_t addr);
+void ip_in(struct rte_mbuf *pkt_buf, struct rte_ipv4_hdr *iph);
+void ip_out(struct rte_mbuf *pkt_buf, struct rte_ipv4_hdr *iph, uint32_t src_ip,
 			uint32_t dst_ip, uint8_t ttl, uint8_t tos, uint8_t proto,
-			uint16_t l4len, struct ether_addr *dst_haddr);
-void icmp_in(void *pkt_buf, struct ipv4_hdr *iph, struct icmp_hdr *icmph);
-void igmp_in(void *pkt_buf, struct ipv4_hdr *iph, struct igmpv2_hdr *igmph);
-void udp_in(struct rte_mbuf *pkt_buf, struct ipv4_hdr *iph,
-			struct udp_hdr *udph);
+			uint16_t l4len, struct rte_ether_addr *dst_haddr);
+void icmp_in(void *pkt_buf, struct rte_ipv4_hdr *iph, struct rte_icmp_hdr *icmph);
+void igmp_in(void *pkt_buf, struct rte_ipv4_hdr *iph, struct igmpv2_hdr *igmph);
+void udp_in(struct rte_mbuf *pkt_buf, struct rte_ipv4_hdr *iph,
+			struct rte_udp_hdr *udph);
 int udp_out(struct rte_mbuf *pkt_buf, struct ip_tuple *id, int len);
 #ifdef ROUTER
-void router_in(struct rte_mbuf *pkt_buf, struct ipv4_hdr *iph,
-			   struct udp_hdr *udph);
+void router_in(struct rte_mbuf *pkt_buf, struct rte_ipv4_hdr *iph,
+			   struct rte_udp_hdr *udph);
 #endif
 
 static inline uint16_t get_local_port(void)
@@ -91,7 +91,7 @@ static inline uint32_t get_local_ip(void)
 	return CFG.host_addr;
 }
 
-static inline void get_local_mac(struct ether_addr *mac)
+static inline void get_local_mac(struct rte_ether_addr *mac)
 {
 	rte_eth_macaddr_get(0, mac); // Assume only one NIC
 }

--- a/netstack/inc/net/utils.h
+++ b/netstack/inc/net/utils.h
@@ -38,13 +38,13 @@ static inline uint32_t ip_str_to_int(const char *ip)
 	if (sscanf(ip, "%hhu.%hhu.%hhu.%hhu", &a, &b, &c, &d) != 4) {
 		return -EINVAL;
 	}
-	addr = IPv4(a, b, c, d);
+	addr = RTE_IPV4(a, b, c, d);
 	return addr;
 }
 
 static inline int str_to_eth_addr(const char *src, unsigned char *dst)
 {
-	struct ether_addr tmp;
+	struct rte_ether_addr tmp;
 
 	if (sscanf(src, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx", &tmp.addr_bytes[0],
 			   &tmp.addr_bytes[1], &tmp.addr_bytes[2], &tmp.addr_bytes[3],
@@ -62,14 +62,14 @@ static inline void ip_addr_to_str(uint32_t addr, char *str)
 
 static inline void pkt_dump(struct rte_mbuf *pkt)
 {
-	struct ether_hdr *ethh = rte_pktmbuf_mtod(pkt, struct ether_hdr *);
-	struct ipv4_hdr *iph = rte_pktmbuf_mtod_offset(pkt, struct ipv4_hdr *,
-												   sizeof(struct ether_hdr));
+	struct rte_ether_hdr *ethh = rte_pktmbuf_mtod(pkt, struct rte_ether_hdr *);
+	struct rte_ipv4_hdr *iph = rte_pktmbuf_mtod_offset(pkt, struct rte_ipv4_hdr *,
+												   sizeof(struct rte_ether_hdr));
 	printf("DST MAC: ");
-	for (int i = 0; i < ETHER_ADDR_LEN; i++)
+	for (int i = 0; i < RTE_ETHER_ADDR_LEN; i++)
 		printf("%hhx ", (char)ethh->d_addr.addr_bytes[i]);
 	printf("\nSRC MAC: ");
-	for (int i = 0; i < ETHER_ADDR_LEN; i++)
+	for (int i = 0; i < RTE_ETHER_ADDR_LEN; i++)
 		printf("%hhx ", (char)ethh->s_addr.addr_bytes[i]);
 	char ipaddr[64];
 	ip_addr_to_str(iph->src_addr, ipaddr);

--- a/netstack/net/eth.c
+++ b/netstack/net/eth.c
@@ -40,15 +40,15 @@
 void eth_in(struct rte_mbuf *pkt_buf)
 {
 	unsigned char *payload = rte_pktmbuf_mtod(pkt_buf, unsigned char *);
-	struct ether_hdr *hdr = (struct ether_hdr *)payload;
-	struct arp_hdr *arph;
-	struct ipv4_hdr *iph;
+	struct rte_ether_hdr *hdr = (struct rte_ether_hdr *)payload;
+	struct rte_arp_hdr *arph;
+	struct rte_ipv4_hdr *iph;
 
-	if (hdr->ether_type == rte_cpu_to_be_16(ETHER_TYPE_ARP)) {
-		arph = (struct arp_hdr *)(payload + (sizeof(struct ether_hdr)));
+	if (hdr->ether_type == rte_cpu_to_be_16(RTE_ETHER_TYPE_ARP)) {
+		arph = (struct rte_arp_hdr *)(payload + (sizeof(struct rte_ether_hdr)));
 		arp_in(pkt_buf, arph);
-	} else if (hdr->ether_type == rte_be_to_cpu_16(ETHER_TYPE_IPv4)) {
-		iph = (struct ipv4_hdr *)(payload + (sizeof(struct ether_hdr)));
+	} else if (hdr->ether_type == rte_be_to_cpu_16(RTE_ETHER_TYPE_IPV4)) {
+		iph = (struct rte_ipv4_hdr *)(payload + (sizeof(struct rte_ether_hdr)));
 		ip_in(pkt_buf, iph);
 	} else {
 		//printf("Unknown ether type: %" PRIu16 "\n",
@@ -58,10 +58,10 @@ void eth_in(struct rte_mbuf *pkt_buf)
 }
 
 int eth_out(struct rte_mbuf *pkt_buf, uint16_t h_proto,
-			struct ether_addr *dst_haddr, uint16_t iplen)
+			struct rte_ether_addr *dst_haddr, uint16_t iplen)
 {
 	/* fill the ethernet header */
-	struct ether_hdr *hdr = rte_pktmbuf_mtod(pkt_buf, struct ether_hdr *);
+	struct rte_ether_hdr *hdr = rte_pktmbuf_mtod(pkt_buf, struct rte_ether_hdr *);
 
 	hdr->d_addr = *dst_haddr;
 	get_local_mac(&hdr->s_addr);
@@ -71,5 +71,5 @@ int eth_out(struct rte_mbuf *pkt_buf, uint16_t h_proto,
 	// pkt_dump(pkt_buf);
 
 	/* enqueue the packet */
-	return dpdk_eth_send(pkt_buf, iplen + sizeof(struct ether_hdr));
+	return dpdk_eth_send(pkt_buf, iplen + sizeof(struct rte_ether_hdr));
 }

--- a/netstack/net/icmp.c
+++ b/netstack/net/icmp.c
@@ -38,15 +38,15 @@
 #include <net/net.h>
 #include <net/utils.h>
 
-static void icmp_echo(void *pkt_buf, struct ipv4_hdr *iph,
-					  struct icmp_hdr *icmph)
+static void icmp_echo(void *pkt_buf, struct rte_ipv4_hdr *iph,
+					  struct rte_icmp_hdr *icmph)
 {
 	int iphlen;
 	int icmplen;
 
 	/* compute icmp length */
-	iphlen = (iph->version_ihl & IPV4_HDR_IHL_MASK) * IPV4_IHL_MULTIPLIER;
-	icmph->icmp_type = IP_ICMP_ECHO_REPLY;
+	iphlen = (iph->version_ihl & RTE_IPV4_HDR_IHL_MASK) * RTE_IPV4_IHL_MULTIPLIER;
+	icmph->icmp_type = RTE_IP_ICMP_ECHO_REPLY;
 
 	icmplen = rte_be_to_cpu_16(iph->total_length) - iphlen;
 
@@ -58,9 +58,9 @@ static void icmp_echo(void *pkt_buf, struct ipv4_hdr *iph,
 		   iph->type_of_service, IPPROTO_ICMP, icmplen, NULL);
 }
 
-void icmp_in(void *pkt_buf, struct ipv4_hdr *iph, struct icmp_hdr *icmph)
+void icmp_in(void *pkt_buf, struct rte_ipv4_hdr *iph, struct rte_icmp_hdr *icmph)
 {
-	if (icmph->icmp_type == IP_ICMP_ECHO_REQUEST)
+	if (icmph->icmp_type == RTE_IP_ICMP_ECHO_REQUEST)
 		icmp_echo(pkt_buf, iph, icmph);
 	else {
 		printf("Wrong ICMP type: %d\n", icmph->icmp_type);

--- a/netstack/net/igmp.c
+++ b/netstack/net/igmp.c
@@ -40,13 +40,13 @@ static void igmp_handle_membership_query(void)
 	int i;
 	struct net_sge *entry;
 	struct rte_mbuf *pkt_buf;
-	struct ipv4_hdr *iph;
+	struct rte_ipv4_hdr *iph;
 	struct igmpv2_hdr *igmph;
 
 	for (i=0;i<CFG.multicast_cnt;i++) {
 		entry = alloc_net_sge();
 		pkt_buf = entry->handle;
-		iph = rte_pktmbuf_mtod_offset(pkt_buf, struct ipv4_hdr *, L2_HDR_LEN);
+		iph = rte_pktmbuf_mtod_offset(pkt_buf, struct rte_ipv4_hdr *, L2_HDR_LEN);
 		igmph = rte_pktmbuf_mtod_offset(pkt_buf, struct igmpv2_hdr *,
 				L3_HDR_LEN+4); // extra space for options
 		igmph->gaddr = rte_cpu_to_be_32(CFG.multicast_ips[i]);
@@ -70,7 +70,7 @@ int igmp_init(void)
 	return 0;
 }
 
-void igmp_in(void *pkt_buf, __attribute__((unused))struct ipv4_hdr *iph,
+void igmp_in(void *pkt_buf, __attribute__((unused))struct rte_ipv4_hdr *iph,
 		struct igmpv2_hdr *igmph)
 {
 	switch(igmph->type) {

--- a/netstack/net/udp.c
+++ b/netstack/net/udp.c
@@ -35,8 +35,8 @@
 #include <net/net.h>
 #include <net/utils.h>
 
-void udp_in(struct rte_mbuf *pkt_buf, struct ipv4_hdr *iph,
-			struct udp_hdr *udph)
+void udp_in(struct rte_mbuf *pkt_buf, struct rte_ipv4_hdr *iph,
+			struct rte_udp_hdr *udph)
 {
 	struct ip_tuple *id;
 	struct net_sge *e;
@@ -49,8 +49,8 @@ void udp_in(struct rte_mbuf *pkt_buf, struct ipv4_hdr *iph,
 
 	e = rte_pktmbuf_mtod_offset(pkt_buf, struct net_sge *,
 								sizeof(struct ip_tuple));
-	e->len = rte_be_to_cpu_16(udph->dgram_len) - sizeof(struct udp_hdr);
-	e->payload = (void *)((unsigned char *)udph + sizeof(struct udp_hdr));
+	e->len = rte_be_to_cpu_16(udph->dgram_len) - sizeof(struct rte_udp_hdr);
+	e->payload = (void *)((unsigned char *)udph + sizeof(struct rte_udp_hdr));
 	e->handle = pkt_buf;
 
 	global_ops->udp_recv(e, id);
@@ -58,18 +58,18 @@ void udp_in(struct rte_mbuf *pkt_buf, struct ipv4_hdr *iph,
 
 int udp_out(struct rte_mbuf *pkt_buf, struct ip_tuple *id, int len)
 {
-	struct ipv4_hdr *iph = rte_pktmbuf_mtod_offset(pkt_buf, struct ipv4_hdr *,
-												   sizeof(struct ether_hdr));
-	struct udp_hdr *udph = rte_pktmbuf_mtod_offset(pkt_buf, struct udp_hdr *,
-												   sizeof(struct ether_hdr) +
-													   sizeof(struct ipv4_hdr));
+	struct rte_ipv4_hdr *iph = rte_pktmbuf_mtod_offset(pkt_buf, struct rte_ipv4_hdr *,
+												   sizeof(struct rte_ether_hdr));
+	struct rte_udp_hdr *udph = rte_pktmbuf_mtod_offset(pkt_buf, struct rte_udp_hdr *,
+												   sizeof(struct rte_ether_hdr) +
+													   sizeof(struct rte_ipv4_hdr));
 
 	udph->dgram_cksum = 0;
-	udph->dgram_len = rte_cpu_to_be_16(len + sizeof(struct udp_hdr));
+	udph->dgram_len = rte_cpu_to_be_16(len + sizeof(struct rte_udp_hdr));
 	udph->src_port = rte_cpu_to_be_16(id->src_port);
 	udph->dst_port = rte_cpu_to_be_16(id->dst_port);
 
 	ip_out(pkt_buf, iph, id->src_ip, id->dst_ip, 64, 0, IPPROTO_UDP,
-		   len + sizeof(struct udp_hdr), NULL);
+		   len + sizeof(struct rte_udp_hdr), NULL);
 	return 0;
 }


### PR DESCRIPTION
Submodule points to "releases" branch (20.08)


Note the changes to rte_eth_conf from:
			.header_split = 0,   /**< Header Split disabled */
			.hw_ip_checksum = 1, /**< IP checksum offload disabled */
			.hw_vlan_filter = 0, /**< VLAN filtering disabled */
			.jumbo_frame = 0,	/**< Jumbo Frame Support disabled */
			.hw_strip_crc = 1,   /**< CRC stripped by hardware */
(deprecated) to:
.offloads = DEV_RX_OFFLOAD_IPV4_CKSUM | DEV_RX_OFFLOAD_KEEP_CRC

(hw_ip_checksum = 1, /**< IP checksum offload disabled */
This is contradictory, no?)


Also added:
max_rx_pkt_len = RTE_ETHER_MAX_LEN
to fix "Ethdev port_id=0 max_rx_pkt_len 0 < min valid value 64" error